### PR TITLE
Add 'all' option to *not* filter broadcaster language.

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -124,7 +124,7 @@ function getStreamList(options) {
         success: function (res) {
             liveStreams = res.streams;
             for (var stream of liveStreams) {
-                if (stream.channel.broadcaster_language === language || stream.channel.language === language) {
+                if (language == "all" || stream.channel.broadcaster_language === language || stream.channel.language === language) {
                     liveBroadcasterLanguageStreams.push(stream);
                 }
             }

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
         <navbar id="nav">
             <select id="select-broadcaster-language">
                 <option value="" disabled selected>Select Broadcasting Language</option>
+                <option value="all">All</option>
                 <option value="fr">French</option>
                 <option value="en">English</option>
             </select>


### PR DESCRIPTION
For some events I want to be check foreign community streams to catch games that aren't broadcasted on the main stream, so I think an "all/any languages/no filter" option would be useful.
