### PR TITLE
Implement #9 - Put the favorite icon + the viewers count in the first line

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,7 +18,7 @@ body {
 
 .stream {
     position: relative;
-    height: 95px;
+    height: 79px;
     background-color: #2B2F38;
     color: #fff;
     opacity: 0;
@@ -132,7 +132,11 @@ body {
     background-position: center;
     background-size: cover;
     right: 10px;
-    top: 20px;
+    top: 12px;
+}
+
+.fa.fa-star {
+    margin-right: 5px;
 }
 
 .fa.fa-star:hover {

--- a/js/popup.js
+++ b/js/popup.js
@@ -94,7 +94,10 @@ function loadPreferences() {
 // Create the DOM element for a stream
 function createStreamElement(stream, htmlContent) {
     if (stream.channel) {
-        htmlContent += '<div class="stream"><a class="stream-title" target="_blank" href="' + stream.channel.url + '">' + stream.channel.display_name + '</a><span>' + stream.channel.status.substring(0, 90) + '</span><span>Viewers: ' + stream.viewers.toLocaleString() + '</span> <div class="stream-logo" style="background-image:url(' + stream.channel.logo + ')"></div><i class="fa fa-star fa-lg" data-stream-name=' + stream.channel.display_name + '></i>';
+        htmlContent += '<div class="stream">'
+            + '<i class="fa fa-star fa-lg" data-stream-name=' + stream.channel.display_name + '></i><a class="stream-title" target="_blank" href="' + stream.channel.url + '">' + stream.channel.display_name + '</a> - ' + stream.viewers.toLocaleString() + ' viewers'
+            + '<span>' + stream.channel.status.substring(0, 90) + '</span> <div class="stream-logo" style="background-image:url(' + stream.channel.logo + ')">'
+            + '</div>';
         //Race icon if race found in stream status
         if (stream.channel.status != null) {
             if (stream.channel.status.match(/terran/i)) {


### PR DESCRIPTION
Implements #9: "Improve readability by displaying viewers count on the same line as the title"

_Note_: no viewer counts icon. Twitch uses an SVG to display its icon.
**Good news:** we can easily dynamically change its color (to make it appropriate when hover/not hover. For example:
![Image](http://puu.sh/p0fZt/a9e846844e.png)
**Bad news:** I'm not sure how to copy that, the node is : 
`<svg class="svg-glyph_live" height="16px" version="1.1" viewBox="0 0 16 16" width="16px" x="0px" y="0px">
  <path clip-rule="evenodd" d="M11,14H5H2v-1l3-3h2L5,8V2h6v6l-2,2h2l3,3v1H11z" fill-rule="evenodd"></path>
</svg>`
